### PR TITLE
Bug: fixes error in pure vignette computation

### DIFF
--- a/source/comp-rlitt_pure_vignette/test/tests/compute/positive_tests.c
+++ b/source/comp-rlitt_pure_vignette/test/tests/compute/positive_tests.c
@@ -64,4 +64,15 @@ void test_compute_positive(void)
                                      test_stub_read_success_msg("i(([3][3]3)([3][3]3)([3][3]3))",
                                                                 "pure_vignette"),
                                      "Error in output");
+    tree.root = &b3b;
+    cfg.wptt  = &tree;
+    ret_val   = comp_rlitt_pure_vignette_config(&cfg);
+
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(ret_val, COMP_DEFS_CONFIG_SUCCESS, "Error in config.");
+    ret_val = comp_rlitt_pure_vignette_compute();
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(ret_val, COMP_DEFS_COMPUTE_SUCCESS, "Error in computation.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("i[]",
+                                     test_stub_read_success_msg("i[3]",
+                                                                "pure_vignette"),
+                                     "Error in output");
 }

--- a/source/comp-rlitt_pure_vignette/test/tests/results/positive_tests.c
+++ b/source/comp-rlitt_pure_vignette/test/tests/results/positive_tests.c
@@ -59,4 +59,15 @@ void test_results_positive(void)
     results = comp_rlitt_pure_vignette_result();
     TEST_ASSERT_NOT_NULL(results);
     TEST_ASSERT_EQUAL_STRING("i(([][])([][])([][]))", results->result);
+
+    tree.root = &b3b;
+    cfg.wptt  = &tree;
+    ret_val   = comp_rlitt_pure_vignette_config(&cfg);
+
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(ret_val, COMP_DEFS_CONFIG_SUCCESS, "Error in config.");
+    ret_val = comp_rlitt_pure_vignette_compute();
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(ret_val, COMP_DEFS_COMPUTE_SUCCESS, "Error in computation.");
+    results = comp_rlitt_pure_vignette_result();
+    TEST_ASSERT_NOT_NULL(results);
+    TEST_ASSERT_EQUAL_STRING("i[]", results->result);
 }

--- a/source/comp-rlitt_pure_vignette/unit-description.md
+++ b/source/comp-rlitt_pure_vignette/unit-description.md
@@ -220,6 +220,7 @@ returns successfully. The result written to the write interface is correct.
     - i([3][3]3)
     - i[3 3 3 3]
     - i(([3][3]3)([3][3]3)([3][3]3))
+    - i[3]
 
 **Expected Output:**
 
@@ -229,6 +230,7 @@ returns successfully. The result written to the write interface is correct.
     - i([][])
     - i((([])))
     - i(([][])([][])([][]))
+    - i[]
 ```
 
 #### Negative Tests
@@ -264,11 +266,17 @@ interface.
     - i([3][3]3)
     - i[3 3 3 3]
     - i(([3][3]3)([3][3]3)([3][3]3))
+    - i[3]
 
 **Expected Output:**
 
 - A positive response.
-- The result is correct.
+- The result is correct:
+    - i((([][])))
+    - i([][])
+    - i((([])))
+    - i(([][])([][])([][]))
+    - i[]
 ```
 
 #### Negative Tests


### PR DESCRIPTION
# 👷🏽‍♀️ Pull Request

Fixes bug where i[n] is output as i instead of i[]

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring

## Description

Minor changes to the C file for the impacted component by removing lines filtering the root from being seen by the walk algo. 

## Testing

Adds test for integral tangles. 

## Checklist

- [x] I have made corresponding changes to the documentation.
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new errors or warnings
- [x] No new tests are failing.
- [x] Any changes beyond one monorepo are justified above
